### PR TITLE
Cleanup delete_event date validation

### DIFF
--- a/calendar_agent.py
+++ b/calendar_agent.py
@@ -243,8 +243,8 @@ def delete_event(details):
         return {"success": False, "error": "Title and date are required"}
 
     try:
-        event_date = datetime.strptime(date_str, "%Y-%m-%d")
-        sy, sm, sd = _date_parts(date_str)
+        # Validate date format
+        datetime.strptime(date_str, "%Y-%m-%d")
 
         script = f"""
         try


### PR DESCRIPTION
## Summary
- remove unused `event_date` and `_date_parts` calls in `delete_event`
- keep simple validation via `datetime.strptime`

## Testing
- `python -m py_compile calendar_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_687dd7363de48331bff9a3b102b213e2