### PR TITLE
Implement duration defaulting and location support

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -44,6 +44,8 @@ calendar_functions = [
                 "title": {"type": "string", "description": "Event title"},
                 "date": {"type": "string", "description": "Event date (YYYY-MM-DD)"},
                 "time": {"type": "string", "description": "Event time (e.g., 14:00)"},
+                "duration": {"type": "integer", "description": "Duration in minutes"},
+                "location": {"type": "string", "description": "Event location"},
             },
             "required": ["title", "date", "time"],
         },


### PR DESCRIPTION
## Summary
- add missing duration warning and location parameter to `create_event`
- expose `duration` and `location` to OpenAI function definition
- test new behaviors in `create_event`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3810f738833196a0d3b3e209e222