### PR TITLE
Add notification system

### DIFF
--- a/future_enhancements.md
+++ b/future_enhancements.md
@@ -68,7 +68,7 @@
 
 ### Phase 2 (Short-term)
 
-1. Smart notification system
+1. ✅ Completed: Smart notification system
 2. Travel time integration
 3. Event templates
 

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from calendar_agent import (
     create_event,
     delete_event,
     move_event,
+    add_notification,
 )
 
 # Main terminal loop
@@ -86,6 +87,13 @@ if __name__ == "__main__":
 
         elif action == "move_event":
             result = move_event(details)
+            if result.get("success"):
+                print(f"✅ {result.get('message')}")
+            else:
+                print(f"❌ Error: {result.get('error')}")
+
+        elif action == "add_notification":
+            result = add_notification(details)
             if result.get("success"):
                 print(f"✅ {result.get('message')}")
             else:

--- a/openai_client.py
+++ b/openai_client.py
@@ -85,6 +85,19 @@ calendar_functions = [
             "required": ["title", "old_date", "new_date", "new_time"],
         },
     },
+    {
+        "name": "add_notification",
+        "description": "Add a notification reminder to an existing event.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Event title"},
+                "date": {"type": "string", "description": "Event date (YYYY-MM-DD)"},
+                "minutes_before": {"type": "integer", "description": "Minutes before event to trigger"},
+            },
+            "required": ["title", "date"],
+        },
+    },
 ]
 
 

--- a/tests/test_calendar_agent.py
+++ b/tests/test_calendar_agent.py
@@ -98,3 +98,26 @@ def test_move_event_invalid_time(monkeypatch):
     })
     assert not result["success"]
     assert "Time must be in HH:MM 24-hour format" in result["error"]
+
+
+def test_add_notification_builds_script(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, capture_output=True, text=True, check=False):
+        captured["script"] = cmd[2]
+        return types.SimpleNamespace(stdout="SUCCESS: Notification added", stderr="")
+
+    monkeypatch.setattr(calendar_agent.subprocess, "run", fake_run)
+    result = calendar_agent.add_notification({
+        "title": "Meet",
+        "date": "2024-08-01",
+        "minutes_before": 30,
+    })
+    assert result["success"]
+    assert "display alarm" in captured["script"] and "30" in captured["script"]
+
+
+def test_add_notification_invalid_date(monkeypatch):
+    result = calendar_agent.add_notification({"title": "t", "date": "2024-13-01"})
+    assert not result["success"]
+    assert "Date must be in YYYY-MM-DD format" in result["error"]

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -41,3 +41,13 @@ def test_interpret_command_success(monkeypatch):
     monkeypatch.setattr(openai_client, "client", fake_client)
     result = openai_client.interpret_command("show events")
     assert result == {"action": "list_all", "details": {}}
+
+
+def test_interpret_command_add_notification(monkeypatch):
+    message = FakeMessage("add_notification", '{"title":"Meet","date":"2024-08-01"}')
+    response = FakeResponse(message)
+    fake_client = FakeClient(response)
+    monkeypatch.setattr(openai_client, "client", fake_client)
+    result = openai_client.interpret_command("remind me")
+    assert result["action"] == "add_notification"
+    assert result["details"]["title"] == "Meet"


### PR DESCRIPTION
## Summary
- support adding notifications for existing events
- expose the new action to the LLM
- update main loop to handle `add_notification`
- document completed Phase 2 step
- test notification handler and OpenAI client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3e4611d0833197015417f54ac7f3