### PR TITLE
Extract CLI output helpers

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from calendar_agent_eventkit import (
     move_event,
     add_notification,
 )
+from utils.cli_output import format_events, format_reminders, print_events_and_reminders
 
 # Main terminal loop
 if __name__ == "__main__":
@@ -43,42 +44,19 @@ if __name__ == "__main__":
             "list_events_only",
             "list_reminders_only",
         ]:
-            # Use new flexible function for date or range
+            # Use CLI output helpers
             result = list_events_and_reminders(start_date, end_date)
             if result.get("error"):
                 print(f"❌ Error: {result['error']}")
                 continue
+            events = result.get("events", [])
+            reminders = result.get("reminders", [])
             if action in ["list_todays_events", "list_all"]:
-                print("\n📅 Events:")
-                events = result.get("events", [])
-                if events:
-                    for event in events:
-                        print(f"  - {event}")
-                else:
-                    print("  (none)")
-                print("\n⏰ Reminders:")
-                reminders = result.get("reminders", [])
-                if reminders:
-                    for reminder in reminders:
-                        print(f"  - {reminder}")
-                else:
-                    print("  (none)")
+                print_events_and_reminders(events, reminders)
             elif action == "list_events_only":
-                print("\n📅 Events:")
-                events = result.get("events", [])
-                if events:
-                    for event in events:
-                        print(f"  - {event}")
-                else:
-                    print("  (none)")
+                print(format_events(events))
             elif action == "list_reminders_only":
-                print("\n⏰ Reminders:")
-                reminders = result.get("reminders", [])
-                if reminders:
-                    for reminder in reminders:
-                        print(f"  - {reminder}")
-                else:
-                    print("  (none)")
+                print(format_reminders(reminders))
 
         elif action == "create_event":
             # Prompt for duration if not provided

--- a/tests/test_cli_output_helpers.py
+++ b/tests/test_cli_output_helpers.py
@@ -1,0 +1,30 @@
+import pytest
+from utils.cli_output import format_events, format_reminders, print_events_and_reminders
+
+
+def test_format_events_empty():
+    assert format_events([]) == "\n📅 Events:\n  (none)"
+
+
+def test_format_events_multiple():
+    events = ["E1", "E2"]
+    expected = "\n📅 Events:\n  - E1\n  - E2"
+    assert format_events(events) == expected
+
+
+def test_format_reminders_empty():
+    assert format_reminders([]) == "\n⏰ Reminders:\n  (none)"
+
+
+def test_format_reminders_multiple():
+    reminders = ["R1", "R2"]
+    expected = "\n⏰ Reminders:\n  - R1\n  - R2"
+    assert format_reminders(reminders) == expected
+
+
+def test_print_events_and_reminders(capsys):
+    events = ["E1"]
+    reminders = ["R1"]
+    print_events_and_reminders(events, reminders)
+    captured = capsys.readouterr()
+    assert captured.out == "\n📅 Events:\n  - E1\n\n⏰ Reminders:\n  - R1\n"

--- a/utils/cli_output.py
+++ b/utils/cli_output.py
@@ -1,0 +1,31 @@
+"""CLI output formatting helpers for calendar assistant."""
+
+from typing import List
+
+
+def format_events(events: List[str]) -> str:
+    """Format a list of event strings into a CLI-friendly block."""
+    output = "\n📅 Events:"
+    if events:
+        for event in events:
+            output += f"\n  - {event}"
+    else:
+        output += "\n  (none)"
+    return output
+
+
+def format_reminders(reminders: List[str]) -> str:
+    """Format a list of reminder strings into a CLI-friendly block."""
+    output = "\n⏰ Reminders:"
+    if reminders:
+        for reminder in reminders:
+            output += f"\n  - {reminder}"
+    else:
+        output += "\n  (none)"
+    return output
+
+
+def print_events_and_reminders(events: List[str], reminders: List[str]) -> None:
+    """Print formatted events and reminders blocks to the CLI."""
+    print(format_events(events))
+    print(format_reminders(reminders))


### PR DESCRIPTION
Move repeated print logic from main.py into a new  module with , , and  helpers, and refactor main to use them. All tests green.