### PR TITLE
chore: configure pre-commit hook to run pytest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        always_run: true


### PR DESCRIPTION
Adds a local pytest hook via .pre-commit-config.yaml to enforce passing tests before each commit